### PR TITLE
Added the ability to override RamlNavigatorFactory constants from a child class.

### DIFF
--- a/DependencyInjection/Factory/RamlNavigatorFactory.php
+++ b/DependencyInjection/Factory/RamlNavigatorFactory.php
@@ -47,10 +47,10 @@ class RamlNavigatorFactory
      */
     public function createNavigator(JsonCoder $jsonCoder)
     {
-        $ramlDocPath = $this->kernel->getRootDir() . self::RAML_DOC_PATH;
+        $ramlDocPath = $this->kernel->getRootDir() . static::RAML_DOC_PATH;
 
         if (!is_readable($ramlDocPath)) {
-            throw new \RuntimeException(self::ERROR_PARAM_TYPE);
+            throw new \RuntimeException(static::ERROR_PARAM_TYPE);
         }
 
         $ramlDoc = $this->parser->parse($ramlDocPath);


### PR DESCRIPTION
It's nice to have the ability to override where the api.raml file is located. By using late static binding, users can extend the RamlNavigatorFactory and update constants, pointing api.raml to a bundle-specific configuration rather than forcing users to place the file in the app/config directory.

Example:
```php
namespace ApiBundle\Factory;

use GoIntegro\Bundle\HateoasBundle\DependencyInjection\Factory\RamlNavigatorFactory as BaseNavigatorFactory;

class RamlNavigatorFactory extends BaseNavigatorFactory
{
    const RAML_DOC_PATH = '/../src/ApiBundle/Resources/config/api.raml';
    const ERROR_PARAM_TYPE = 'The "api.raml" file was not found!';
}
```

Ideally, the path to the api.raml file would be configurable via config.yml, rather than having to add compiler passes that change service definitions to custom implementations.