### PR TITLE
fixed improper use of keyword "continue"

### DIFF
--- a/DependencyInjection/Compiler/FilterCompilerPass.php
+++ b/DependencyInjection/Compiler/FilterCompilerPass.php
@@ -23,7 +23,9 @@ class FilterCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition(self::SERVICE_NAME)) continue;
+        if (!$container->hasDefinition(self::SERVICE_NAME))  {
+            return;
+        }
 
         $definition = $container->getDefinition(self::SERVICE_NAME);
         $taggedServices = $container->findTaggedServiceIds(self::TAG_NAME);

--- a/DependencyInjection/Compiler/LocaleCompilerPass.php
+++ b/DependencyInjection/Compiler/LocaleCompilerPass.php
@@ -23,7 +23,9 @@ class LocaleCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition(self::LOCALE_PARSER_SERVICE)) continue;
+        if (!$container->hasDefinition(self::LOCALE_PARSER_SERVICE))  {
+            return;
+        }
 
         $definition = $container->getDefinition(self::LOCALE_PARSER_SERVICE);
         $taggedServices = $container->findTaggedServiceIds(self::TAG_NAME);

--- a/DependencyInjection/Compiler/SortingCompilerPass.php
+++ b/DependencyInjection/Compiler/SortingCompilerPass.php
@@ -23,7 +23,9 @@ class SortingCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition(self::SERVICE_NAME)) continue;
+        if (!$container->hasDefinition(self::SERVICE_NAME)) {
+            return;
+        }
 
         $definition = $container->getDefinition(self::SERVICE_NAME);
         $taggedServices = $container->findTaggedServiceIds(self::TAG_NAME);


### PR DESCRIPTION
Fixed improper uses of keyword "continue", which are causing runtime errors in PHP7.
